### PR TITLE
修复博客园上传js错误

### DIFF
--- a/src/app-store.js
+++ b/src/app-store.js
@@ -21,15 +21,15 @@ class DataStore extends Store {
     SegmentFaultTokenKey = 'segmentFault-token-key';
     //简书
     JianShuCookieKey = 'jianShu-cookie-key';
-
+    CnblogsToken = 'CnblogsToken'
     // 图片上传快捷键
     uploadClipboardPicSwitch = 'uploadClipboardPicSwitch';
     // 富文本转纯文字
     coverToTextSwitch = 'coverToTextSwitch';
 
     constructor(settings) {
-        const baseConfig = {name: 'blog-helper'};
-        const finalConfig = {...baseConfig, ...settings};
+        const baseConfig = { name: 'blog-helper' };
+        const finalConfig = { ...baseConfig, ...settings };
         super(finalConfig)
     }
 
@@ -152,7 +152,16 @@ class DataStore extends Store {
         }
         return null
     }
+    SetCnblogsToken(v) {
+        return this.set(this.CnblogsToken, v)
 
+    }
+    GetCnblogsToken() {
+        if (this.has(this.CnblogsToken)) {
+            return this.get(this.CnblogsToken)
+        }
+        return null
+    }
     setOsChinaUserId(v) {
         return this.set(this.OsChinaUserIdKey, v)
     }

--- a/src/blog/cnblogs.js
+++ b/src/blog/cnblogs.js
@@ -5,7 +5,9 @@ const jsdom = require("jsdom");
 const querystring = require('querystring');
 const FormData = require('form-data');
 const fs = require('fs');
-
+const { Console } = require('console');
+const axios = require('axios')
+const { session } = require('electron')
 //上传图片到博客园
 function uploadPictureToCnBlogs(filePath) {
     return new Promise((resolve, reject) => {
@@ -19,16 +21,16 @@ function uploadPictureToCnBlogs(filePath) {
         headers.Connection = 'close';
         //自己的headers属性在这里追加
         let request = https.request({
-                                        host: 'upload.cnblogs.com',
-                                        method: 'POST',
-                                        path: '/imageuploader/CorsUpload',
-                                        agent: false,
-                                        headers: headers
-                                    }, function (res) {
+            host: 'upload.cnblogs.com',
+            method: 'POST',
+            path: '/imageuploader/CorsUpload',
+            agent: false,
+            headers: headers
+        }, function (res) {
             let str = '';
             res.on('data', function (buffer) {
-                       str += buffer;//用字符串拼接
-                   }
+                str += buffer;//用字符串拼接
+            }
             );
             res.on('end', () => {
                 if (res.statusCode === 200) {
@@ -46,7 +48,7 @@ function uploadPictureToCnBlogs(filePath) {
         formData.pipe(request);
 
         request.on('error', function (e) {
-            reject('网络连接异常'+e.message)
+            reject('网络连接异常' + e.message)
         });
     })
 }
@@ -55,108 +57,68 @@ let cnBlog_url = 'https://i1.cnblogs.com/EditPosts.aspx?opt=1';
 
 //发布文章到博客园
 function publishArticleToCnBlogs(title, content, isPublish) {
+
     return new Promise((resolve, reject) => {
-        let req = https.get(cnBlog_url, {
-            agent: false,
+        axios.get(cnBlog_url, {
             headers: {
                 'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:45.0) Gecko/20100101 Firefox/45.0',
                 'Cookie': dataStore.getCnBlogCookies(),
-                'Connection': 'close'
+                'Connection': 'close',
             }
-        }, res => {
-            let str = '';
-            res.on('data', function (buffer) {
-                str += buffer; //用字符串拼接
-            });
-            res.on('end', () => {
-                //上传之后result就是返回的结果
-                const dom = new jsdom.JSDOM(str);
-                const VIEWSTATE = dom.window.document.querySelector('#__VIEWSTATE').value;
-                const VIEWSTATEGENERATOR = dom.window.document.querySelector(
-                    '#__VIEWSTATEGENERATOR').value;
-                if (!VIEWSTATE) {
-                    reject('请先登录博客园');
-                    return
-                }
-                //真正发布文章
-                publishArticleToCnBlogFact(title, content, VIEWSTATE, VIEWSTATEGENERATOR, resolve,
-                                           reject, isPublish)
-            });
-        });
-
-        req.on('error', function (e) {
-            reject('网络连接异常'+e.message)
-        });
+        }).then(res => {
+            let token = dataStore.GetCnblogsToken()
+            //let cookies = session.defaultSession.cookies.get()
+            if (!token) {
+                reject('请先登录博客园');
+                return
+            }
+            publishArticleToCnBlogFact(title, content, resolve, reject, isPublish)
+        }).catch(err => {
+            console.log(err)
+        })
     })
 }
 
-function publishArticleToCnBlogFact(title, content, VIEWSTATE, VIEWSTATEGENERATOR, resolve,
-                                    reject, isPublish) {
-    const parms = {
-        '__VIEWSTATE': VIEWSTATE,
-        '__VIEWSTATEGENERATOR': VIEWSTATEGENERATOR,
-        'Editor$Edit$txbTitle': title,
-        'Editor$Edit$EditorBody': content,
-        'Editor$Edit$Advanced$ckbPublished': 'on',
-        'Editor$Edit$Advanced$chkDisplayHomePage': 'on',
-        'Editor$Edit$Advanced$chkComments': 'on',
-        'Editor$Edit$Advanced$chkMainSyndication': 'on',
-        'Editor$Edit$Advanced$txbEntryName': '',
-        'Editor$Edit$Advanced$txbExcerpt': '',
-        'Editor$Edit$Advanced$txbTag': '',
-        'Editor$Edit$Advanced$tbEnryPassword': ''
-    };
-    if (isPublish) {
-        parms['Editor$Edit$lkbPost'] = '发布'
-    } else {
-        parms['Editor$Edit$lkbDraft'] = '存为草稿'
+function publishArticleToCnBlogFact(title, content, resolve,
+    reject, isPublish) {
+    let params = {
+        "id": null,
+        "postType": 1,
+        "title": title,
+        "postBody": content,
     }
-    const data = querystring.stringify(parms);
-
-    let options = {
-        method: 'POST',
-        agent: false,
+    axios({
+        method: 'post',
+        url: 'https://i.cnblogs.com/api/posts',
+        data: JSON.stringify(params),
         headers: {
-            'Accept-Encoding': 'deflate, br',
-            'Connection': 'close',
             "Accept-Language": "zh-CN,zh;q=0.8,en-US;q=0.5,en;q=0.3",
             'Referer': 'https://i.cnblogs.com',
             'Accept': '*/*',
             'Origin': 'https://i.cnblogs.com',
-            'Content-Type': 'application/x-www-form-urlencoded',
-            'Content-Length': data.length,
+            'Content-Type': 'application/json',
             'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:45.0) Gecko/20100101 Firefox/45.0',
-            'Cookie': dataStore.getCnBlogCookies()
-
+            'Cookie': dataStore.getCnBlogCookies(),
+            'x-xsrf-token': dataStore.GetCnblogsToken()
         }
-    };
+    }).then(res => {
+        if (res.status == 200) {
+            resolve(res.data.url)
+        }
+        // console.log(res)
+    }).catch(res => {
+        reject('发布失败！\n1.文章标题已存在\n2.尚未登录博客园\n3.发布频繁请稍后再试\n4.超过当日100篇限制')
 
-    let req = https.request(cnBlog_url, options, function (res) {
-        res.setEncoding('utf-8');
-        let str = '';
-        res.on('data', function (chunk) {
-            str += chunk
-        });
-        res.on('end', () => {
-            if (res.statusCode === 302) {
-                //发布成功
-                const dom = new jsdom.JSDOM(str);
-                const a = dom.window.document.body.getElementsByTagName('a')[0];
-                let url = 'https://i.cnblogs.com' + a.href;
-                resolve(url)
-            } else {
-                //发布失败
-                reject('发布失败！\n1.文章标题已存在\n2.尚未登录博客园\n3.发布频繁请稍后再试\n4.超过当日100篇限制')
-            }
-        });
-    });
+    })
 
-    req.on('error', function (e) {
-        reject('网络连接异常'+e.message)
-    });
 
-    req.write(data);
-    req.end()
+    // const dom = new jsdom.JSDOM(str);
+    // const a = dom.window.document.body.getElementsByTagName('a')[0];
+    // let url = 'https://i.cnblogs.com' + a.href;
+
+
+    // //发布失败
+
 }
 
 exports.uploadPictureToCnBlogs = uploadPictureToCnBlogs;

--- a/src/cookie/app-login.js
+++ b/src/cookie/app-login.js
@@ -1,4 +1,4 @@
-const {BrowserWindow, session} = require('electron');
+const { BrowserWindow, session } = require('electron');
 const https = require('https');
 const jsDom = require("jsdom");
 const icon = require('../common/app-icon');
@@ -8,20 +8,27 @@ const dataStore = new DataStore();
 //登录某网站获取Cookie通用方法
 function getSiteCookie(url, callback) {
     let win = new BrowserWindow(
-        {width: 700, height: 600, icon: icon.iconFile, title: '【登陆成功后关闭窗口即可完成设置】'});
+        { width: 700, height: 600, icon: icon.iconFile, title: '【登陆成功后关闭窗口即可完成设置】' });
     win.loadURL(url).then();
     win.on('close', () => {
         // 查询所有与设置的 URL 相关的所有 cookies.
-        session.defaultSession.cookies.get({url: url})
+        if (url == 'https://www.cnblogs.com/') {
+            url = '.cnblogs.com'
+        }
+        session.defaultSession.cookies.get({ domain: url })
             .then((cookies) => {
                 let cookieString = '';
                 for (let cookie of cookies) {
+                    if (cookie.name == 'XSRF-TOKEN') {
+                        dataStore.SetCnblogsToken(cookie.value)
+                    }
                     cookieString += cookie.name + '=' + cookie.value + '; '
                 }
                 callback(cookieString.trim())
             }).catch((error) => {
-            console.log(error)
-        });
+                console.log(error)
+            });
+
         win = null
     });
     win.on('page-title-updated', (e) => {


### PR DESCRIPTION
博客园接口地址变了获取不到指定元素 所以js错误  
现在博客提交都变成了接口的形式 不太会用Https库 所以换成了axios
提交的时候有一个 的cookie 必须要在后台界面才能获取到
所以登录完成后 需要手动转到后台的管理界 即可获取到那个cookie  就可以正常提交了

